### PR TITLE
Minor updates to fix build on MacOS/merge in upstream libssh changes

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -80,6 +80,10 @@ target_link_libraries(keygen ${LIBSSH_SHARED_LIBRARY})
 
 add_executable(libsshpp libsshpp.cpp)
 target_link_libraries(libsshpp ${LIBSSH_SHARED_LIBRARY})
+# libsshpp.hpp uses `noexcept` which is a keyword since C++11, so explicitly
+# required C++11 here for this build
+set_property(TARGET libsshpp PROPERTY CXX_STANDARD 11)
+set_property(TARGET libsshpp PROPERTY CXX_STANDARD_REQUIRED ON)
 
 add_executable(libsshpp_noexcept libsshpp_noexcept.cpp)
 target_link_libraries(libsshpp_noexcept ${LIBSSH_SHARED_LIBRARY})

--- a/include/libssh/session.h
+++ b/include/libssh/session.h
@@ -106,6 +106,15 @@ struct ssh_common_struct {
     int log_verbosity; /* verbosity of the log functions */
 };
 
+enum ssh_socket_states_e {
+	SSH_SOCKET_NONE,
+	SSH_SOCKET_CONNECTING,
+	SSH_SOCKET_CONNECTED,
+	SSH_SOCKET_EOF,
+	SSH_SOCKET_ERROR,
+	SSH_SOCKET_CLOSED
+};
+
 struct ssh_socket_struct {
 	socket_t fd;
 	int fd_is_socket;

--- a/include/libssh/sftp.h
+++ b/include/libssh/sftp.h
@@ -201,13 +201,18 @@ struct sftp_statvfs_struct {
 };
 
 /**
- * @brief Start a new sftp session.
+ * @brief Creates a new sftp session.
+ *
+ * This function creates a new sftp session and allocates a new sftp channel
+ * with the server inside of the provided ssh session. This function call is
+ * usually followed by the sftp_init(), which initializes SFTP protocol itself.
  *
  * @param session       The ssh session to use.
  *
  * @return              A new sftp session or NULL on error.
  *
  * @see sftp_free()
+ * @see sftp_init()
  */
 LIBSSH_API sftp_session sftp_new(ssh_session session);
 
@@ -232,7 +237,10 @@ LIBSSH_API sftp_session sftp_new_channel(ssh_session session, ssh_channel channe
 LIBSSH_API void sftp_free(sftp_session sftp);
 
 /**
- * @brief Initialize the sftp session with the server.
+ * @brief Initialize the sftp protocol with the server.
+ *
+ * This function involves the SFTP protocol initialization (as described
+ * in the SFTP specification), including the version and extensions negotiation.
  *
  * @param sftp          The sftp session to initialize.
  *

--- a/src/dh-gex.c
+++ b/src/dh-gex.c
@@ -24,9 +24,10 @@
 #include "config.h"
 
 #include <errno.h>
+#include <stdlib.h>
 #include <stdbool.h>
-#include <string.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "libssh/priv.h"
 #include "libssh/dh-gex.h"

--- a/src/dh-gex.c
+++ b/src/dh-gex.c
@@ -38,7 +38,7 @@
 #include "libssh/buffer.h"
 #include "libssh/session.h"
 
-/* Minimum, recommanded and maximum size of DH group */
+/* Minimum, recommended and maximum size of DH group */
 #define DH_PMIN 2048
 #define DH_PREQ 2048
 #define DH_PMAX 8192

--- a/src/dh-gex.c
+++ b/src/dh-gex.c
@@ -59,13 +59,17 @@ static struct ssh_packet_callbacks_struct ssh_dhgex_client_callbacks = {
     .user = NULL
 };
 
-int min(int a, int b) {
+#ifndef min
+static int min(int a, int b) {
     return a > b ? b : a;
 }
+#endif
 
-int max(int a, int b) {
+#ifndef max
+static int max(int a, int b) {
     return a > b ? a : b;
 }
+#endif
 
 /** @internal
  * @brief initiates a diffie-hellman-group-exchange kex

--- a/src/dh-gex.c
+++ b/src/dh-gex.c
@@ -59,6 +59,14 @@ static struct ssh_packet_callbacks_struct ssh_dhgex_client_callbacks = {
     .user = NULL
 };
 
+int min(int a, int b) {
+    return a > b ? b : a;
+}
+
+int max(int a, int b) {
+    return a > b ? a : b;
+}
+
 /** @internal
  * @brief initiates a diffie-hellman-group-exchange kex
  */

--- a/src/dh.c
+++ b/src/dh.c
@@ -794,7 +794,7 @@ void ssh_print_hash(enum ssh_publickey_hash_type type,
         return;
     }
 
-	SSH_LOG(SSH_LOG_CRYPTO, fingerprint);
+	SSH_LOG(SSH_LOG_CRYPTO, "%s", fingerprint);
 
     SAFE_FREE(fingerprint);
 }

--- a/src/libcrypto.c
+++ b/src/libcrypto.c
@@ -55,7 +55,7 @@
 #include <openssl/des.h>
 #endif
 
-#ifdef HAVE_OPENSSL_MODES_H
+#if defined(HAVE_OPENSSL_MODES_H) || defined(HAVE_OPENSSL_CRYPTO_CTR128_ENCRYPT)
 #include <openssl/modes.h>
 #endif
 
@@ -72,10 +72,6 @@
 
 #ifdef HAVE_OPENSSL_EVP_KDF_CTX_NEW_ID
 #include <openssl/kdf.h>
-#endif
-
-#ifdef HAVE_OPENSSL_CRYPTO_CTR128_ENCRYPT
-#include <openssl/modes.h>
 #endif
 
 #include "libssh/crypto.h"

--- a/src/misc.c
+++ b/src/misc.c
@@ -460,7 +460,7 @@ void ssh_print_hexa(const char *descr, const unsigned char *what, size_t len) {
     if (hexa == NULL) {
       return;
     }
-	_ssh_log(SSH_LOG_CRYPTO, descr, hexa);
+	_ssh_log(SSH_LOG_CRYPTO, descr, "%s", hexa);
 
     free(hexa);
 }

--- a/src/socket.c
+++ b/src/socket.c
@@ -64,14 +64,6 @@
  * @{
  */
 
-enum ssh_socket_states_e {
-	SSH_SOCKET_NONE,
-	SSH_SOCKET_CONNECTING,
-	SSH_SOCKET_CONNECTED,
-	SSH_SOCKET_EOF,
-	SSH_SOCKET_ERROR,
-	SSH_SOCKET_CLOSED
-};
 
 static int sockets_initialized = 0;
 


### PR DESCRIPTION
This fixes some minor issues that were stopping a full build on MacOS from succeeding, and updates some minor errors (warnings that were turned to errors) for format string issues, and explicitly declares a part of the project to be C++11 so that we avoid compilation errors due to the header expecting C++11 features.